### PR TITLE
change buffer size to 64 to allow protocol switching on windows

### DIFF
--- a/src/driver_vive.c
+++ b/src/driver_vive.c
@@ -568,7 +568,7 @@ void vive_switch_mode(struct SurviveUSBInfo *driverInfo, enum LightcapMode light
 	SurviveObject *w = driverInfo->so;
 	if (driverInfo->timeWithoutFlag == 0) {
 		driverInfo->timeWithoutFlag = 1;
-		uint8_t buffer[9] = {0};
+		uint8_t buffer[64] = {0};
 		size_t buffer_length = 0;
 		if (survive_device_is_rf(driverInfo->device_info)) {
 			buffer[0] = VIVE_REPORT_COMMAND;
@@ -581,11 +581,11 @@ void vive_switch_mode(struct SurviveUSBInfo *driverInfo, enum LightcapMode light
 			buffer[6] = 2;
 			buffer[7] = lightcapMode == LightcapMode_raw2 ? 1 : 0;
 			buffer[8] = 0;
-			buffer_length = 9;
+			buffer_length = 64;
 		} else {
 			buffer[0] = VIVE_REPORT_CHANGE_MODE;
 			buffer[1] = (lightcapMode == LightcapMode_raw1) ? 1 : (lightcapMode == LightcapMode_raw2) ? 3 : 0;
-			buffer_length = 5;
+			buffer_length = 64;
 		}
 
 		if (driverInfo->handle) {


### PR DESCRIPTION
Tested with a Vive Pro controller on 1.0 and 2.0 Lighthouses
with a 3rd party Watchman dongle running version 1526689969 
on Windows

Before fix error occured: "Could not send raw mode to WM0 -1"
