### PR TITLE
Fix build warning: Initialize variables before logging

### DIFF
--- a/src/survive_sensor_activations.c
+++ b/src/survive_sensor_activations.c
@@ -132,6 +132,8 @@ static inline bool SurviveSensorActivations_check_outlier(SurviveSensorActivatio
 	FLT *oldangle = &self->angles[sensor_id][lh][axis];
 	FLT chauvenet_criterion = -1;
 	FLT dev = 0;
+	FLT measured_dev = -1;
+	int cnt = -1;
 	const char *failure_reason = "None";
 	if (self->angles_center_dev[lh][axis] == 0) {
 		goto accept_data;
@@ -143,9 +145,9 @@ static inline bool SurviveSensorActivations_check_outlier(SurviveSensorActivatio
 		goto delta_failure;
 	}
 
-	FLT measured_dev = self->angles_center_dev[lh][axis];
+	measured_dev = self->angles_center_dev[lh][axis];
 	dev = linmath_max(self->params.filterVarianceMin, measured_dev);
-	int cnt = self->angles_center_cnt[lh][axis];
+	cnt = self->angles_center_cnt[lh][axis];
 	if (cnt < self->params.filterOutlierMinCount)
 		cnt = self->params.filterOutlierMinCount;
 	chauvenet_criterion = linmath_chauvenet_criterion(angle, self->angles_center_x[lh][axis], dev, cnt);


### PR DESCRIPTION
Initialize two variables before accessing them in a goto block for logging.

Fixes build warnings like these:

```
In file included from /usr/include/stdio.h:970,
                 from /usr/include/malloc.h:25,
                 from /home/spacy/src/libsurvive/redist/linmath.h:7,
                 from /home/spacy/src/libsurvive/include/libsurvive/survive_types.h:5,
                 from /home/spacy/src/libsurvive/include/libsurvive/poser.h:4,
                 from /home/spacy/src/libsurvive/include/libsurvive/survive.h:5,
                 from /home/spacy/src/libsurvive/src/survive_sensor_activations.c:4:
In function ‘snprintf’,
    inlined from ‘SurviveSensorActivations_check_outlier’ at /home/spacy/src/libsurvive/src/survive_sensor_activations.c:183:3:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:68:10: warning: ‘measured_dev’ may be used uninitialized [-Wmaybe-uninitialized]
   68 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   69 |                                    __glibc_objsize (__s), __fmt,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   70 |                                    __va_arg_pack ());
      |                                    ~~~~~~~~~~~~~~~~~
/home/spacy/src/libsurvive/src/survive_sensor_activations.c: In function ‘SurviveSensorActivations_check_outlier’:
/home/spacy/src/libsurvive/src/survive_sensor_activations.c:146:13: note: ‘measured_dev’ was declared here
  146 |         FLT measured_dev = self->angles_center_dev[lh][axis];
      |             ^~~~~~~~~~~~
In function ‘snprintf’,
    inlined from ‘SurviveSensorActivations_check_outlier’ at /home/spacy/src/libsurvive/src/survive_sensor_activations.c:183:3:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:68:10: warning: ‘cnt’ may be used uninitialized [-Wmaybe-uninitialized]
   68 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   69 |                                    __glibc_objsize (__s), __fmt,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   70 |                                    __va_arg_pack ());
      |                                    ~~~~~~~~~~~~~~~~~
/home/spacy/src/libsurvive/src/survive_sensor_activations.c: In function ‘SurviveSensorActivations_check_outlier’:
/home/spacy/src/libsurvive/src/survive_sensor_activations.c:148:13: note: ‘cnt’ was declared here
  148 |         int cnt = self->angles_center_cnt[lh][axis];
      |             ^~~
```