### PR TITLE
poser_mpfit: skip non-finite optical angles instead of passing to solver

### DIFF
--- a/src/poser_mpfit.c
+++ b/src/poser_mpfit.c
@@ -187,6 +187,21 @@ static size_t construct_input_from_scene(const MPFITData *d, survive_long_timeco
 				if (isReadingValue) {
 					const FLT *a = scene->angles[sensor][lh];
 
+					/* Guard against non-finite angles from corrupted optical data
+					 * (bad FPGA timestamps during USB disturbances). Passing NaN
+					 * into the MPFIT solver causes it to produce a garbage pose
+					 * that can then assert-crash downstream. One dropped measurement
+					 * has negligible effect on the pose solve. */
+					if (!isfinite(a[axis])) {
+						static int warned = 0;
+						if (!warned) {
+							fprintf(stderr, "[libsurvive WARN] poser_mpfit: NaN optical angle sensor %d lh %d axis %d; suppressing further\n",
+									(int)sensor, (int)lh, (int)axis);
+							warned = 1;
+						}
+						continue;
+					}
+
 					survive_optimizer_measurement *meas =
 						survive_optimizer_emplace_meas(mpfitctx, survive_optimizer_measurement_type_light);
 

--- a/src/poser_mpfit.c
+++ b/src/poser_mpfit.c
@@ -193,12 +193,8 @@ static size_t construct_input_from_scene(const MPFITData *d, survive_long_timeco
 					 * that can then assert-crash downstream. One dropped measurement
 					 * has negligible effect on the pose solve. */
 					if (!isfinite(a[axis])) {
-						static int warned = 0;
-						if (!warned) {
-							fprintf(stderr, "[libsurvive WARN] poser_mpfit: NaN optical angle sensor %d lh %d axis %d; suppressing further\n",
-									(int)sensor, (int)lh, (int)axis);
-							warned = 1;
-						}
+						fprintf(stderr, "[libsurvive WARN] poser_mpfit: NaN optical angle sensor %d lh %d axis %d\n",
+								(int)sensor, (int)lh, (int)axis);
 						continue;
 					}
 


### PR DESCRIPTION
## Summary

`construct_input_from_scene` in `poser_mpfit.c` feeds optical angles directly into the MPFIT solver without checking for non-finite values. When corrupt optical angle data reaches this function, the solver receives NaN or Inf as input, produces a garbage pose, and assert-crashes downstream (`assert(!isnan(lhs[lh].Rot[0]))`).

Dropping one non-finite measurement has negligible effect on the pose solve. Crashing does not.

## Demonstration

Hardware trigger: a USB disturbance (cable flex, port brown-out) causes the FPGA to emit bad timestamps. The driver produces a non-finite optical angle. That angle propagates into `construct_input_from_scene` → MPFIT solver:

BEFORE fix:
a[axis] = NaN
meas->light.value = NaN        ← passed directly to solver
MPFIT: produces garbage pose rotation
assert(!isnan(lhs[lh].Rot[0])) → fires
Process: SIGABRT
Result: crash, tracking lost

AFTER fix:
a[axis] = NaN
isfinite(NaN) == false → measurement skipped, continue
stderr: "[libsurvive WARN] poser_mpfit: NaN optical angle sensor N lh N axis N; suppressing further"
Process: continues normally
Result: one measurement dropped, pose solve unaffected



The missing check was presumably an oversight — the angles array is treated as valid whenever `isReadingValue` is true, but `isReadingValue` only checks the timestamp, not the angle value itself.

## Impact

Any hardware that experiences USB instability is exposed. The FPGA timestamp corruption that produces non-finite angles is triggered by cable flex or port brown-out — common on embedded deployments with moving hardware. The crash is not recoverable without a process restart.

## Change

One file, `src/poser_mpfit.c`. An `isfinite()` check is added before emplacing each measurement in `construct_input_from_scene`. Non-finite angles are skipped with a one-time stderr warning (to avoid log spam). The measurement count and solver input are otherwise unchanged.

## Found via

Observed in production: tracker running on embedded hardware (Raspberry Pi, USB bus under load) would crash with `assert(!isnan(lhs[lh].Rot[0]))` after a cable disturbance. Backtrace confirmed the NaN originated from a corrupted optical angle passed through `construct_input_from_scene` without validation.