### PR TITLE
Fix 32-bit (ILP32) type assumptions

### DIFF
--- a/src/driver_playback.c
+++ b/src/driver_playback.c
@@ -222,7 +222,7 @@ static int parse_and_run_imu(const char *line, SurvivePlaybackData *driver, bool
 		return 0;
 
 	char dev[10];
-	int timecode = 0;
+	survive_timecode timecode = 0;
 	FLT accelgyro[9] = { 0 };
 	int mask;
 	int id;
@@ -231,7 +231,7 @@ static int parse_and_run_imu(const char *line, SurvivePlaybackData *driver, bool
 	char i_char = 0;
 
 	int rr = sscanf(line,
-					"%s %c %d %d " FLT_sformat " " FLT_sformat " " FLT_sformat " " FLT_sformat " " FLT_sformat
+					"%s %c %d %u " FLT_sformat " " FLT_sformat " " FLT_sformat " " FLT_sformat " " FLT_sformat
 					" " FLT_sformat " " FLT_sformat " " FLT_sformat " " FLT_sformat "%d",
 					dev, &i_char, &mask, &timecode, &accelgyro[0], &accelgyro[1], &accelgyro[2], &accelgyro[3],
 					&accelgyro[4], &accelgyro[5], &accelgyro[6], &accelgyro[7], &accelgyro[8], &id);

--- a/src/driver_usbmon.c
+++ b/src/driver_usbmon.c
@@ -790,7 +790,14 @@ static int gzip_cookie_close(void *cookie) { return gzclose((gzFile)cookie); }
 
 static ssize_t gzip_cookie_read(void *cookie, char *buf, size_t nbytes) { return gzread((gzFile)cookie, buf, nbytes); }
 
-int gzip_cookie_seek(void *cookie, z_off_t *pos, int __w) { return gzseek((gzFile)cookie, *pos, __w); }
+static int gzip_cookie_seek(void *cookie, off64_t *pos, int whence) {
+	z_off64_t r = gzseek64((gzFile)cookie, (z_off64_t)*pos, whence);
+	if (r < 0)
+		return -1;
+
+	*pos = (off64_t)r;
+	return 0;
+}
 
 cookie_io_functions_t gzip_cookie = {
 	.close = gzip_cookie_close, .write = gzip_cookie_write, .read = gzip_cookie_read, .seek = gzip_cookie_seek};

--- a/src/survive_sensor_activations.c
+++ b/src/survive_sensor_activations.c
@@ -454,7 +454,7 @@ SURVIVE_EXPORT survive_long_timecode SurviveSensorActivations_long_timecode_ligh
 	use that as a basis. It's worth noting that I've never seen a system develop this while running; it would
 	likely cause some chaos if it did since it'd kick the kalman out of sorts.
 	***/
-	if (self->last_imu != 0 && labs(time_sync_error) > 48000000) {
+	if (self->last_imu != 0 && llabs(time_sync_error) > 48000000) {
 		int64_t offset = 0x10000000;
 		int scale = DIV_ROUND_CLOSEST(time_sync_error, offset);
 		initial_time -= offset * scale;


### PR DESCRIPTION
Three independent places assume LP64 type widths. On i686 the first breaks the build outright; the second aborts six replay tests.

**`src/driver_usbmon.c`** — `gzip_cookie_seek()` declared its position argument as `z_off_t *`, but glibc's `cookie_seek_function_t` is always `int (*)(void *, __off64_t *, int)`. Identical types on LP64, mismatched on ILP32, and `-Werror=incompatible-pointer-types` makes it fatal. Now uses `off64_t`/`gzseek64()`. Also fixes the callback's return contract — it returned the new offset instead of 0/-1 and never wrote `*pos`, so `fseek()`/`ftell()` on a compressed playback stream misbehaved on *every* arch.

**`src/driver_playback.c`** — `parse_and_run_imu()` read the IMU timecode into an `int` via `%d`; every other timecode field in the `.rec.gz` format is `survive_timecode`/`%u`. The counter exceeds `INT32_MAX` after ~45 s (2³¹ / 48 MHz). glibc's `%d` round-trips those on LP64 via its 64-bit accumulator, but saturates at `LONG_MAX` on ILP32 — every later timecode clamps to `2147483647`. That freezes `last_imu`, so the 2²⁸ lightcap/IMU desync correction in `SurviveSensorActivations_long_timecode_light()` yanks the light timecode back ~5.58 s and trips `assert(tracker->model.t - t < 1)`.

**`src/survive_sensor_activations.c`** — `labs()` takes a `long` but `time_sync_error` is `int64_t`, truncating on ILP32 before the magnitude test. No observed failure on its own (`DIV_ROUND_CLOSEST()` already uses the untruncated value), but same bug class, adjacent code.

### Testing

Fedora rawhide mock, `-m32 -march=i686 -msse2 -mfpmath=sse`:

| | i686 |
|---|---|
| before | does not compile |
| + usbmon fix | builds; `85% tests passed, 6 tests failed out of 41` |
| + all three | `100% tests passed, 0 tests failed out of 41` |

Failing set was `compare-test-index`, `drone`, `haagh-tracking`, `stool-test2`, `tracker-bad-tracking`, `tracker-throw-compare` — all i686-only, all deterministic across repeated