### PR TITLE
driver_vive: fix infinite loop when closing HIDAPI devices

### DIFF
--- a/src/driver_vive.hidapi.h
+++ b/src/driver_vive.hidapi.h
@@ -189,6 +189,15 @@ static inline void survive_close_usb_device(struct SurviveUSBInfo *usbInfo) {
 	}
 
 	free(usbInfo->handle);
+	usbInfo->handle = 0;
+
+	// HIDAPI has no transfer-completion callback to raise request_close,
+	// this needs to be set manually to avoid hanging in survive_vive_close().
+	for (size_t j = 0; j < usbInfo->interface_cnt; j++) {
+		usbInfo->interfaces[j].shutdown = 1;
+		usbInfo->interfaces[j].assoc_obj = 0;
+	}
+	usbInfo->request_close = true;
 #ifndef HID_NONBLOCKING
 	for (int j = 0; j < MAX_INTERFACES_PER_DEVICE; j++) {
 		OGJoinThread(sv->udev[i].interfaces->servicethread);


### PR DESCRIPTION
(Re-opening #369, which was closed by accident when I deleted my fork.)

Fixes #312.

### Problem

On Windows, `USE_HIDAPI` defaults to `ON`, and `survive_vive_close()` never
returns:

```c
while (sv->udev_cnt) {          // never reaches 0
#ifndef HIDAPI
    libusb_handle_events(sv->usbctx);
#endif
    for (int i = 0; i < sv->udev_cnt; i++) {
        if (survive_handle_close_request_flag(sv->udev[i])) i--;
    }
}
```

`survive_handle_close_request_flag()` only acts when `usbInfo->request_close`
is set. In the HIDAPI backend that flag is raised only in `HAPIReceiver()` when
`hid_read()` returns a negative value; `survive_close_usb_device()` closes the
HID handles without setting it. The libusb backend is unaffected because
`libusb_handle_events()` drives the completion callbacks that raise the flag,
and that call is `#ifndef HIDAPI`.

Besides hanging the process, this also means `config_save()` (which runs later
inside `survive_close()`) is never reached, so lighthouse calibration is never
written to `config.json` and has to be redone on every launch.

### Fix

Raise the flag (and mark the interfaces shut down, mirroring the libusb path)
when the device is actually closed. Freeing the handle there is safe because
`survive_usb_handle_close()` is a no-op in this backend.

### Testing

Windows 11 x64, MSVC, master, `USE_HIDAPI=ON`, two Vive Trackers (2018) over
USB with SteamVR 2.0 base stations:

- before: `survive_simple_close()` did not return after 60 s; `config.json`
  never contained `lighthouse0`/`lighthouse1`
- after: it returns immediately, and `config.json` gets the lighthouse entries,
  so a second launch starts tracking without recalibrating
